### PR TITLE
feat: `RefuseToMapException`, thrown by property mapper if it needs to leave the target property unmapped

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.64.0" installed="3.64.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.68.0" installed="3.68.0" location="./tools/php-cs-fixer" copy="false"/>
 </phive>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # CHANGELOG
 
-## 1.13.6
+## 1.14.0
 
 * chore: rector run
 * fix: check file existence before unlinking, suppresses warning
+* feat: `RefuseToMapException`, thrown by property mapper if it needs to leave
+  the target property unmapped
 
 ## 1.13.5
 

--- a/src/Exception/RefuseToMapException.php
+++ b/src/Exception/RefuseToMapException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/mapper package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\Mapper\Exception;
+
+class RefuseToMapException extends \RuntimeException implements ExceptionInterface {}

--- a/src/MapperFactory.php
+++ b/src/MapperFactory.php
@@ -225,7 +225,7 @@ class MapperFactory
         private readonly ?NormalizerInterface $normalizer = null,
         private readonly ?DenormalizerInterface $denormalizer = null,
         private readonly CacheItemPoolInterface $propertyInfoExtractorCache = new ArrayAdapter(),
-        private readonly LoggerInterface $logger = new NullLogger()
+        private readonly LoggerInterface $logger = new NullLogger(),
     ) {}
 
     /**

--- a/src/Transformer/Processor/ObjectProcessor/ObjectProcessor.php
+++ b/src/Transformer/Processor/ObjectProcessor/ObjectProcessor.php
@@ -19,6 +19,7 @@ use Rekalogika\Mapper\Context\Context;
 use Rekalogika\Mapper\Context\ExtraTargetValues;
 use Rekalogika\Mapper\Context\MapperOptions;
 use Rekalogika\Mapper\Exception\ExceptionInterface;
+use Rekalogika\Mapper\Exception\RefuseToMapException;
 use Rekalogika\Mapper\Exception\UnexpectedValueException;
 use Rekalogika\Mapper\MainTransformer\MainTransformerInterface;
 use Rekalogika\Mapper\ObjectCache\ObjectCache;
@@ -418,7 +419,7 @@ final readonly class ObjectProcessor implements ObjectProcessorInterface
                 $constructorArguments->addUnsetSourceProperty($sourceProperty);
 
                 continue;
-            } catch (UnsupportedPropertyMappingException) {
+            } catch (UnsupportedPropertyMappingException | RefuseToMapException) {
                 continue;
             }
         }
@@ -581,7 +582,7 @@ final readonly class ObjectProcessor implements ObjectProcessorInterface
                 mandatory: false,
                 context: $context,
             );
-        } catch (UninitializedSourcePropertyException | UnsupportedPropertyMappingException) {
+        } catch (UninitializedSourcePropertyException | UnsupportedPropertyMappingException | RefuseToMapException) {
             return $target;
         }
 

--- a/tests/config/rekalogika-mapper/generated-mappings.php
+++ b/tests/config/rekalogika-mapper/generated-mappings.php
@@ -785,63 +785,69 @@ return function (MappingCollection $mappingCollection) : void {
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 244
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 246
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\Bar::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\Baz::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 199
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 201
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\ChildOfSomeObject::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\ChildOfSomeObjectDto::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 182
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 184
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\ChildOfSomeObject::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectDto::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 241
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 243
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\Foo::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\Baz::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 216
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 218
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObject::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\ChildOfSomeObjectDto::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 271
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 273
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObject::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\ObjectWithChild1::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 284
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 286
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObject::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\ObjectWithChild2::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 165
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 167
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObject::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectDto::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 233
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 235
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObject::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithConstructorDto::class
     );
     
     $mappingCollection->addObjectMapping(
-        // tests/src/IntegrationTest/PropertyMappingTest.php on line 297
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 299
         source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObject::class,
         target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithDateTimeImmutableDto::class
+    );
+    
+    $mappingCollection->addObjectMapping(
+        // tests/src/IntegrationTest/PropertyMappingTest.php on line 309
+        source: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithUninitializedVariable::class,
+        target: \Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithUninitializedVariableDto::class
     );
     
     $mappingCollection->addObjectMapping(

--- a/tests/src/Fixtures/PropertyMapper/SomeObjectWithUninitializedVariable.php
+++ b/tests/src/Fixtures/PropertyMapper/SomeObjectWithUninitializedVariable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/mapper package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\Mapper\Tests\Fixtures\PropertyMapper;
+
+/** @psalm-suppress MissingConstructor */
+class SomeObjectWithUninitializedVariable
+{
+    public string $propertyA;
+}

--- a/tests/src/Fixtures/PropertyMapper/SomeObjectWithUninitializedVariableDto.php
+++ b/tests/src/Fixtures/PropertyMapper/SomeObjectWithUninitializedVariableDto.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/mapper package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\Mapper\Tests\Fixtures\PropertyMapper;
+
+/** @psalm-suppress MissingConstructor */
+class SomeObjectWithUninitializedVariableDto
+{
+    public string $propertyA;
+}

--- a/tests/src/IntegrationTest/PropertyMappingTest.php
+++ b/tests/src/IntegrationTest/PropertyMappingTest.php
@@ -29,6 +29,8 @@ use Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObject;
 use Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectDto;
 use Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithConstructorDto;
 use Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithDateTimeImmutableDto;
+use Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithUninitializedVariable;
+use Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithUninitializedVariableDto;
 use Rekalogika\Mapper\Tests\Services\PropertyMapper\PropertyMapperWithClassAttribute;
 use Rekalogika\Mapper\Tests\Services\PropertyMapper\PropertyMapperWithClassAttributeWithoutExplicitProperty;
 use Rekalogika\Mapper\Tests\Services\PropertyMapper\PropertyMapperWithConstructorWithClassAttribute;
@@ -298,6 +300,14 @@ class PropertyMappingTest extends FrameworkTestCase
 
         $this->assertInstanceOf(SomeObjectWithDateTimeImmutableDto::class, $result);
         $this->assertNotSame($originalTargetValue, $result->getProperty());
+    }
 
+    public function testFromUninitializedVariable(): void
+    {
+        $source = new SomeObjectWithUninitializedVariable();
+        $target = new SomeObjectWithUninitializedVariableDto();
+        $result = $this->mapper->map($source, $target);
+
+        $this->assertFalse(isset($result->propertyA));
     }
 }

--- a/tests/src/Services/PropertyMapper/PropertyMapperFromUnitializedVariable.php
+++ b/tests/src/Services/PropertyMapper/PropertyMapperFromUnitializedVariable.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/mapper package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\Mapper\Tests\Services\PropertyMapper;
+
+use Rekalogika\Mapper\Attribute\AsPropertyMapper;
+use Rekalogika\Mapper\Exception\RefuseToMapException;
+use Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithUninitializedVariable;
+use Rekalogika\Mapper\Tests\Fixtures\PropertyMapper\SomeObjectWithUninitializedVariableDto;
+
+#[AsPropertyMapper(
+    targetClass: SomeObjectWithUninitializedVariableDto::class,
+)]
+class PropertyMapperFromUnitializedVariable
+{
+    #[AsPropertyMapper('propertyA')]
+    public function mapPropertyA(SomeObjectWithUninitializedVariable $object): string
+    {
+        try {
+            return $object->propertyA;
+        } catch (\Error $e) { // @phpstan-ignore-line
+            if (str_contains($e->getMessage(), 'must not be accessed before initialization')) {
+                throw new RefuseToMapException();
+            }
+
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
resolves https://github.com/rekalogika/mapper/issues/257